### PR TITLE
Add HTTP proxy support for akka-http HTTP requests

### DIFF
--- a/example.conf
+++ b/example.conf
@@ -44,6 +44,19 @@ link-listener {
   }
 
   youtube-api-key = "" // Optional, if set, tries to parse youtube link titles using the youtube API which seems more stable than the website
+
+  use-http-proxy = true // Optional, if set, will use the default akka http proxy settings for all non-youtube/non-twitter http requests
+
+  // Additionally, akka needs to be told the proxy server's host and port.
+  // For example, putting the following configuration in "akka.conf"
+  //
+  //  akka.http.client.proxy.https {
+  //      host = "127.0.0.1"
+  //      port = 8888
+  //  }
+  //
+  // and adding "-Dconfig.file=akka.conf" to the JVM command line will result
+  // in akka using the HTTP proxy listening on port 8888 on localhost.
 }
 
 pronoun-listener {

--- a/src/main/scala/codes/co2/ircbot/config/BotConfiguration.scala
+++ b/src/main/scala/codes/co2/ircbot/config/BotConfiguration.scala
@@ -31,7 +31,7 @@ case class GeneralConfig(
 
 case class TwitterApi(consumerToken: ConsumerToken, accessToken: AccessToken)
 
-case class LinkListenerConfig(boldTitles: Option[Boolean], twitterApi: Option[TwitterApi], youtubeApiKey: Option[String])
+case class LinkListenerConfig(boldTitles: Option[Boolean], twitterApi: Option[TwitterApi], youtubeApiKey: Option[String], useHttpProxy: Option[Boolean])
 
 case class AdminListenerConfig(helpText: String, puppetMasters: Option[Seq[String]])
 
@@ -48,7 +48,7 @@ object BotConfiguration {
     .at("link-listener").load[LinkListenerConfig]
     .fold(failures => {
       log.info(s"Could not load link-listener config, reason ${failures.toList.map(_.description)} Using default config.")
-      LinkListenerConfig(None, None, None)
+      LinkListenerConfig(None, None, None, None)
     }, success => success)
 
   def loadAdminListenerConfig(path: Path): AdminListenerConfig = ConfigSource.default(ConfigSource.file(path))


### PR DESCRIPTION
I run an instance of this bot on a host which has multiple IP addresses, and I use an HTTP proxy in front of the bot to ensure that only certain source addresses are used when making outgoing HTTP requests (as the different addresses are used by different functions on that machine).

This makes use of `akka-http`'s built-in HTTP proxy functionality. As well as setting `link-listener.use-http-proxy = true` in the bot configuration file, this additionally requires configuring `akka` with details of the HTTP proxy by loading a mix-in configuration file using Pureconfig (e.g. with the `config.file` system property).

For example, I currently run my instance of this bot with `java -Dconfig.file=akka.conf -jar urlbot.jar urlbot.conf`, with
```
link-listener {
    use-http-proxy = true
}
```
in `urlbot.conf` and
```
akka.http.client {
    proxy {
        https {
            host = "127.0.0.1
            port = 8888
        }
    }
}
```
in `akka.conf`.

Note that this doesn't cover the YouTube or Twitter functionality, as I don't use those features.